### PR TITLE
refactor: replace eval() with window.eval()

### DIFF
--- a/src/AdvancedSiteNotices/core.ts
+++ b/src/AdvancedSiteNotices/core.ts
@@ -48,8 +48,8 @@ export const advancedSiteNotices = (): void => {
 		// FIXME: This shouldn't be using eval on data entered in wikitext.
 		// If that data is malformed it will throw an exception e.g. criteria = "(false))"
 		try {
-			// eslint-disable-next-line security/detect-eval-with-expression, no-eval
-			return eval(criteria);
+			// eslint-disable-next-line no-eval
+			return window.eval(criteria);
 		} catch {
 			return false;
 		}

--- a/src/HotCat/HotCat.js
+++ b/src/HotCat/HotCat.js
@@ -3076,8 +3076,8 @@ import {hotCatMessages} from './HotCat-messages';
 					let do_submit = true;
 					if (oldSubmit) {
 						if (typeof oldSubmit === 'string') {
-							// eslint-disable-next-line security/detect-eval-with-expression, no-eval
-							do_submit = eval(oldSubmit);
+							// eslint-disable-next-line no-eval
+							do_submit = window.eval(oldSubmit);
 						} else if (oldSubmit instanceof Function) {
 							do_submit = oldSubmit.apply(form, [oldSubmit, ...args]);
 						}


### PR DESCRIPTION
To avoid sing direct eval with a bundler