### PR TITLE
chore: revert 9a86cd1

### DIFF
--- a/src/AdvancedSiteNotices/.eslintrc
+++ b/src/AdvancedSiteNotices/.eslintrc
@@ -5,7 +5,6 @@
 			{
 				"varsIgnorePattern": "^_"
 			}
-		],
-		"camelcase": "off"
+		]
 	}
 }

--- a/src/AdvancedSiteNotices/modules/i18n.ts
+++ b/src/AdvancedSiteNotices/modules/i18n.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const getI18nMessages: GetI18nMessages = () => {
 	const {localize} = i18n;
 	return {

--- a/src/AdvancedSiteNotices/modules/util/matchCriteria.ts
+++ b/src/AdvancedSiteNotices/modules/util/matchCriteria.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-eval, @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unused-vars */
+/* eslint-disable camelcase, no-eval, @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unused-vars */
 import {WG_USER_GROUPS, WG_USER_LANGUAGE} from '../constant';
 
 const testCriteria = (criteria: string): boolean => {

--- a/src/AutoLink/.eslintrc
+++ b/src/AutoLink/.eslintrc
@@ -1,5 +1,0 @@
-{
-	"rules": {
-		"camelcase": "off"
-	}
-}

--- a/src/AutoLink/modules/constant.ts
+++ b/src/AutoLink/modules/constant.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line camelcase
 const WG_ACTION: MediaWikiConfigMap_WgAction = mw.config.get('wgAction');
 const WG_CANONICAL_NAMESPACE: string = mw.config.get('wgCanonicalNamespace');
 const WG_CANONICAL_SPECIAL_PAGE_NAME: string = mw.config.get('wgCanonicalSpecialPageName').toString();

--- a/src/Cat-a-lot/modules/.eslintrc
+++ b/src/Cat-a-lot/modules/.eslintrc
@@ -1,6 +1,0 @@
-{
-	"rules": {
-		"camelcase": "off",
-		"mediawiki/msg-doc": "off"
-	}
-}

--- a/src/Cat-a-lot/modules/constant.ts
+++ b/src/Cat-a-lot/modules/constant.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const API_ENTRY_POINT: string = mw.util.wikiScript('api');
 const API_TAG = 'Cat-a-lot';
 const DEFAULT_SETTING = [

--- a/src/Cat-a-lot/modules/core.ts
+++ b/src/Cat-a-lot/modules/core.ts
@@ -1,3 +1,4 @@
+/* eslint-disable mediawiki/msg-doc */
 import {
 	API_ENTRY_POINT,
 	API_TAG,

--- a/src/RRD/modules/.eslintrc
+++ b/src/RRD/modules/.eslintrc
@@ -1,5 +1,0 @@
-{
-	"rules": {
-		"camelcase": "off"
-	}
-}

--- a/src/RRD/modules/messages.ts
+++ b/src/RRD/modules/messages.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 export const message = {
 	edit_summary: window.wgULS(
 		'[[MediaWiki:Gadget-RRD.js|半自动提报]]修订版本删除',


### PR DESCRIPTION
disabling eslint rules should be done within the smallest possible scope,
such as a specific line or file.