### PR TITLE
fix(util): the `scrollTop` method options

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -159,6 +159,7 @@ const scrollTop = (
 		typeof effectsOptionsOrDuration === 'number'
 			? {
 					duration: effectsOptionsOrDuration,
+					easing: 'swing',
 			  }
 			: effectsOptionsOrDuration;
 	$('html, body').animate(


### PR DESCRIPTION
missing default `option.seasing` parameter