### PR TITLE
Revert "fix: eslint errors"

### DIFF
--- a/src/DiffLink/modules/addPortletLink.ts
+++ b/src/DiffLink/modules/addPortletLink.ts
@@ -35,7 +35,7 @@ const addPortletLink = ({
 	let element: HTMLLIElement | null = document.querySelector('#t-difflink');
 	if (!element) {
 		element = mw.util.addPortletLink(
-			document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+			document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 			'#',
 			text,
 			't-difflink',

--- a/src/DisamAssist/modules/core.js
+++ b/src/DisamAssist/modules/core.js
@@ -37,7 +37,7 @@ export const install = () => {
 			if (new RegExp(cfg.disamRegExp).test(getTitle())) {
 				const startMainLink = $(
 					mw.util.addPortletLink(
-						document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+						document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 						'#',
 						txt.startMain,
 						'ca-disamassist-main'
@@ -45,7 +45,7 @@ export const install = () => {
 				).on('click', startMain);
 				const startSameLink = $(
 					mw.util.addPortletLink(
-						document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+						document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 						'#',
 						txt.startSame,
 						'ca-disamassist-same'
@@ -55,7 +55,7 @@ export const install = () => {
 			} else {
 				startLink = $(
 					mw.util.addPortletLink(
-						document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+						document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 						'#',
 						txt.start,
 						'ca-disamassist-page'

--- a/src/EnhancedSpecialSearch/modules/core.ts
+++ b/src/EnhancedSpecialSearch/modules/core.ts
@@ -52,8 +52,8 @@ export const enhancedSpecialSearch = (): void => {
 	};
 	const enhancedSpecialSearchMain = (_config: OptionData[]): void => {
 		const searchElement: HTMLElement | null =
-			document.querySelector('#search') ?? document.querySelector('#powersearch');
-		const targetElement: HTMLElement | null = document.querySelector('#mw-search-top-table');
+			document.getElementById('search') ?? document.getElementById('powersearch');
+		const targetElement: HTMLElement | null = document.getElementById('mw-search-top-table');
 		if (!searchElement || !targetElement) {
 			return;
 		}

--- a/src/Group-user_JS/modules/loadEditFormJs.ts
+++ b/src/Group-user_JS/modules/loadEditFormJs.ts
@@ -2,7 +2,7 @@ export const loadEditFormJS = (): void => {
 	/* 加载编辑界面脚本 */
 	if (
 		['edit', 'submit'].includes(mw.config.get('wgAction')) ||
-		(mw.config.get('wgAction') === 'view' && document.querySelector('#ca-addsection'))
+		(mw.config.get('wgAction') === 'view' && document.getElementById('ca-addsection'))
 	) {
 		mw.loader.using(['ext.gadget.EditForm', 'ext.gadget.EditForm_JS']);
 	} else {

--- a/src/HRTProtectLink/modules/core.ts
+++ b/src/HRTProtectLink/modules/core.ts
@@ -16,13 +16,13 @@ const fullProtectURL = mw.util.getUrl(mw.config.get('wgPageName'), {
 
 export const HRTProtectLink = (): void => {
 	mw.util.addPortletLink(
-		document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+		document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 		semiProtectURL,
 		getMessage('Semi-protect HRT'),
 		't-hrt-semiprotect'
 	);
 	mw.util.addPortletLink(
-		document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+		document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 		fullProtectURL,
 		getMessage('Full-protect HRT'),
 		't-hrt-fullprotect'

--- a/src/LogFilter/modules/core.ts
+++ b/src/LogFilter/modules/core.ts
@@ -24,7 +24,7 @@ export const filterLists = {
 		mw.messages.set(filterLists.i18n);
 		// Create portlet link
 		const portletlink: HTMLLIElement | null = mw.util.addPortletLink(
-			document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+			document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 			'#',
 			mw.msg('filter-portlet-text'),
 			'ca-rxfilter',

--- a/src/Navigation_popups/modules/core.js
+++ b/src/Navigation_popups/modules/core.js
@@ -46,16 +46,16 @@ export const popups = () => {
 			return;
 		}
 		container.ranSetupTooltipsAlready = !remove;
-		const anchors = container.querySelectorAll('a');
+		const anchors = container.getElementsByTagName('a');
 		setupTooltipsLoop(anchors, 0, 250, 100, remove, popData);
 	};
 	const defaultPopupsContainer = () => {
 		if (getValueOf('popupOnlyArticleLinks')) {
 			return (
 				document.querySelector('.skin-vector-2022 .vector-body') ||
-				document.querySelector('#mw_content') ||
-				document.querySelector('#content') ||
-				document.querySelector('#article') ||
+				document.getElementById('mw_content') ||
+				document.getElementById('content') ||
+				document.getElementById('article') ||
 				document
 			);
 		}
@@ -105,9 +105,9 @@ export const popups = () => {
 	// eliminate popups from the TOC
 	// This also kills any onclick stuff that used to be going on in the toc
 	const rmTocTooltips = () => {
-		const toc = document.querySelector('#toc');
+		const toc = document.getElementById('toc');
 		if (toc) {
-			const tocLinks = toc.querySelectorAll('a');
+			const tocLinks = toc.getElementsByTagName('A');
 			const tocLen = tocLinks.length;
 			for (let j = 0; j < tocLen; ++j) {
 				removeTooltip(tocLinks[j], true);
@@ -201,7 +201,7 @@ export const popups = () => {
 		if (lTitle.toString(true) !== aTitle.toString(true)) {
 			return false;
 		}
-		let el = document.querySelector(`#${anch}`);
+		let el = document.getElementById(anch);
 		while (el && typeof el.nodeName === 'string') {
 			const nt = el.nodeName.toLowerCase();
 			if (nt === 'li') {
@@ -1558,10 +1558,10 @@ export const popups = () => {
 	};
 	Insta.dump = function (from, to) {
 		if (typeof from === 'string') {
-			from = document.querySelector(`#${from}`);
+			from = document.getElementById(from);
 		}
 		if (typeof to === 'string') {
-			to = document.querySelector(`#${to}`);
+			to = document.getElementById(to);
 		}
 		to.innerHTML = this.convert(from.value);
 	};
@@ -3234,7 +3234,7 @@ export const popups = () => {
 			// console.error('[Popups] popupId is not defined in setPopupHTML, html='+str.substring(0,100));
 			popupId = pg.idNumber;
 		}
-		const popupElement = document.querySelector(`#${elementId}${popupId}`);
+		const popupElement = document.getElementById(elementId + popupId);
 		if (popupElement) {
 			if (!append) {
 				popupElement.innerHTML = '';
@@ -3409,7 +3409,7 @@ export const popups = () => {
 			when = 250;
 		}
 		const popTips = () => {
-			setupTooltips(document.querySelector(`#${id}`), false, true, popData);
+			setupTooltips(document.getElementById(id), false, true, popData);
 		};
 		return () => {
 			setTimeout(popTips, when, popData);
@@ -4683,7 +4683,7 @@ export const popups = () => {
 			log('popupsInsertImage failed :(');
 			return;
 		}
-		const popupImage = document.querySelector(`#popupImg${id}`);
+		const popupImage = document.getElementById(`popupImg${id}`);
 		if (!popupImage) {
 			log('could not find insertion point for image');
 			return;
@@ -4699,7 +4699,7 @@ export const popups = () => {
 		} else {
 			log("fullsize imagethumb, but not sure if it's an image");
 		}
-		const a = document.querySelector(`#popupImageLink${id}`);
+		const a = document.getElementById(`popupImageLink${id}`);
 		if (a === null) {
 			return null;
 		}
@@ -5517,7 +5517,7 @@ export const popups = () => {
 			}
 			let dragHandle;
 			if (handleName) {
-				dragHandle = document.querySelector(`#${handleName}`);
+				dragHandle = document.getElementById(handleName);
 			}
 			if (!dragHandle) {
 				dragHandle = this.mainDiv;

--- a/src/OnlineAdmins/modules/core.ts
+++ b/src/OnlineAdmins/modules/core.ts
@@ -5,7 +5,7 @@ import {initMwApi} from '../../util';
 export const onlineAdmins = (): void => {
 	// Create portlet link
 	const portletLinkOnline: HTMLLIElement | null = mw.util.addPortletLink(
-		document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+		document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 		'#',
 		getMessage('Online'),
 		't-onlineadmin'

--- a/src/PagePatroller/PagePatroller.ts
+++ b/src/PagePatroller/PagePatroller.ts
@@ -4,7 +4,7 @@ import {pagePatroller} from './modules/core';
 	if (
 		mw.config.get('wgNamespaceNumber') < 0 ||
 		mw.config.get('wgPageName') === 'Qiuwen:首页' ||
-		document.querySelectorAll('.noarticletext').length
+		document.getElementsByClassName('noarticletext').length > 0
 	) {
 		return;
 	}

--- a/src/PrintOptions/PrintOptions.js
+++ b/src/PrintOptions/PrintOptions.js
@@ -181,7 +181,9 @@
 				printStyle += '*{color:#000 !important}';
 			}
 			if (printStyle) {
-				document.querySelector('#printStyle')?.remove();
+				if (document.getElementById('printStyle')) {
+					document.getElementById('printStyle').remove();
+				}
 				const styleTag = document.createElement('style');
 				styleTag.id = 'printStyle';
 				styleTag.media = 'print';

--- a/src/PurgePageCache/modules/core.ts
+++ b/src/PurgePageCache/modules/core.ts
@@ -25,7 +25,7 @@ export const purgePageCache = (): void => {
 	};
 
 	const element: HTMLLIElement | null = mw.util.addPortletLink(
-		document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+		document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 		'#',
 		getMessage('Purge'),
 		'ca-purge',

--- a/src/QuickImport/QuickImport.ts
+++ b/src/QuickImport/QuickImport.ts
@@ -99,7 +99,7 @@ if (mw.config.get('wgNamespaceNumber') === 6 && !$('#mw-noarticletext').length) 
 
 const buttonLabel = $('.redirectText a')[0] ? '重定向目标' : '页面';
 const element: HTMLLIElement | null = mw.util.addPortletLink(
-	document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+	document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 	'#',
 	`导入${mw.config.get('wgNamespaceNumber') === 6 ? (label === '' ? '页面' : `文件（${label}）`) : `${buttonLabel}`}`,
 	't-import'

--- a/src/Report/modules/addPortletLink.ts
+++ b/src/Report/modules/addPortletLink.ts
@@ -8,7 +8,7 @@ const addPortletLink = (): void => {
 
 	const linkTilte: string = getMessage('Report');
 	mw.util.addPortletLink(
-		document.querySelector('#p-pagemisc') ? 'p-pagemisc' : 'p-tb',
+		document.getElementById('p-pagemisc') ? 'p-pagemisc' : 'p-tb',
 		URL,
 		linkTilte,
 		't-report',

--- a/src/ShortURL/ShortURL.ts
+++ b/src/ShortURL/ShortURL.ts
@@ -3,7 +3,7 @@ import {shortURL} from './modules/core';
 (() => {
 	if (
 		mw.config.get('wgNamespaceNumber') === -1 ||
-		document.querySelectorAll('.noarticletext').length ||
+		document.getElementsByClassName('noarticletext').length > 0 ||
 		mw.config.get('wgAction') !== 'view'
 	) {
 		return;

--- a/src/SiteCommon_JS/modules/tippy.ts
+++ b/src/SiteCommon_JS/modules/tippy.ts
@@ -3,7 +3,7 @@ import {getMessage} from './i18n';
 
 const loadTippy = (): void => {
 	mw.loader.using('ext.CollapsibleSidebar.js').then((): void => {
-		tippy(document.querySelector('#sidebarButton') as HTMLElement, {
+		tippy(document.getElementById('sidebarButton') as HTMLElement, {
 			arrow: true,
 			content: getMessage('CollapseExpandSidebar'),
 			placement: 'left',
@@ -12,7 +12,7 @@ const loadTippy = (): void => {
 
 	if (WG_SKIN === 'vector') {
 		mw.loader.using('ext.CollapsibleSidebar.vector').then(() => {
-			tippy(document.querySelector('#sidebarCollapse') as HTMLElement, {
+			tippy(document.getElementById('sidebarCollapse') as HTMLElement, {
 				arrow: true,
 				content: getMessage('CollapseExpandSidebar'),
 				placement: 'right',
@@ -21,7 +21,7 @@ const loadTippy = (): void => {
 	}
 
 	mw.loader.using('ext.DarkMode').then((): void => {
-		tippy(document.querySelector('#darkmode-button') as HTMLElement, {
+		tippy(document.getElementById('darkmode-button') as HTMLElement, {
 			arrow: true,
 			content: getMessage('EnableDisableDarkMode'),
 			placement: 'left',

--- a/src/TranslateVariants/TranslateVariants.ts
+++ b/src/TranslateVariants/TranslateVariants.ts
@@ -2,7 +2,7 @@ import {translateVariants} from './modules/core';
 
 if (/^MediaWiki:[^/]+(\/zh)?$/.test(mw.config.get('wgPageName'))) {
 	const link: HTMLLIElement | null = mw.util.addPortletLink(
-		document.querySelector('#p-cactions') ? 'p-cactions' : 'p-tb',
+		document.getElementById('p-cactions') ? 'p-cactions' : 'p-tb',
 		'#',
 		window.wgULS('转换变体', '轉換變體')
 	);

--- a/src/Twinkle/modules/friendlytag.js
+++ b/src/Twinkle/modules/friendlytag.js
@@ -20,8 +20,8 @@
 			// file tagging
 		} else if (
 			mw.config.get('wgNamespaceNumber') === 6 &&
-			!document.querySelector('#mw-sharedupload') &&
-			document.querySelector('#mw-imagepage-section-filehistory')
+			!document.getElementById('mw-sharedupload') &&
+			document.getElementById('mw-imagepage-section-filehistory')
 		) {
 			Twinkle.tag.mode = wgULS('文件', '檔案');
 			Twinkle.tag.modeEn = 'file';
@@ -267,7 +267,7 @@
 				});
 				break;
 		}
-		if (document.querySelectorAll('.patrollink').length) {
+		if (document.getElementsByClassName('patrollink').length) {
 			form.append({
 				type: 'checkbox',
 				list: [
@@ -736,7 +736,7 @@
 			generateLinks(checkbox);
 		}
 		// tally tags added/removed, update statusNode text
-		const statusNode = document.querySelector('#tw-tag-status');
+		const statusNode = document.getElementById('tw-tag-status');
 		$('[name=tags], [name=existingTags]').on('click', function () {
 			if (this.name === 'tags') {
 				Twinkle.tag.status.numAdded += this.checked ? 1 : -1;

--- a/src/Twinkle/modules/twinkle.js
+++ b/src/Twinkle/modules/twinkle.js
@@ -280,11 +280,11 @@
 	 */
 	Twinkle.addPortlet = (navigation, id, text, type, nextnodeid) => {
 		// sanity checks, and get required DOM nodes
-		const root = document.querySelector(`#${navigation}`) || document.querySelector(navigation);
+		const root = document.getElementById(navigation) || document.querySelector(navigation);
 		if (!root) {
 			return null;
 		}
-		const item = document.querySelector(`#${id}`);
+		const item = document.getElementById(id);
 		if (item) {
 			if (item.parentNode && item.parentNode === root) {
 				return item;
@@ -293,7 +293,7 @@
 		}
 		let nextnode;
 		if (nextnodeid) {
-			nextnode = document.querySelector(`#${nextnodeid}`);
+			nextnode = document.getElementById(nextnodeid);
 		}
 		// verify/normalize input
 		const skin = mw.config.get('skin');

--- a/src/Twinkle/modules/twinkleconfig.js
+++ b/src/Twinkle/modules/twinkleconfig.js
@@ -1108,10 +1108,10 @@
 	Twinkle.config.init = () => {
 		// create the config page at Twinkle.getPref('configPage')
 		if (mw.config.get('wgPageName') === Twinkle.getPref('configPage') && mw.config.get('wgAction') === 'view') {
-			if (!document.querySelector('#twinkle-config')) {
+			if (!document.getElementById('twinkle-config')) {
 				return; // maybe the page is misconfigured, or something - but any attempt to modify it will be pointless
 			}
-			const contentdiv = document.querySelector('#twinkle-config-content');
+			const contentdiv = document.getElementById('twinkle-config-content');
 			contentdiv.textContent = ''; // clear children
 			// start a table of contents
 			const toctable = document.createElement('div');
@@ -1692,23 +1692,23 @@
 	Twinkle.config.resetPref = (pref) => {
 		switch (pref.type) {
 			case 'boolean':
-				document.querySelector(`#${pref.name}`).checked = Twinkle.defaultConfig[pref.name];
+				document.getElementById(pref.name).checked = Twinkle.defaultConfig[pref.name];
 				break;
 			case 'string':
 			case 'integer':
 			case 'enum':
-				document.gquerySelector(`#${pref.name}`).value = Twinkle.defaultConfig[pref.name];
+				document.getElementById(pref.name).value = Twinkle.defaultConfig[pref.name];
 				break;
 			case 'set':
 				for (const [itemkey] of Object.entries(pref.setValues)) {
-					if (document.querySelector(`#${pref.name}_${itemkey}`)) {
-						document.querySelector(`#${pref.name}_${itemkey}`).checked =
+					if (document.getElementById(`${pref.name}_${itemkey}`)) {
+						document.getElementById(`${pref.name}_${itemkey}`).checked =
 							Twinkle.defaultConfig[pref.name].includes(itemkey);
 					}
 				}
 				break;
 			case 'customList':
-				$(document.querySelector(`#${pref.name}`)).data('value', Twinkle.defaultConfig[pref.name]);
+				$(document.getElementById(pref.name)).data('value', Twinkle.defaultConfig[pref.name]);
 				break;
 			default:
 				mw.notify(`twinkleconfig: unknown data type for preference ${pref.name}`, {
@@ -1736,7 +1736,7 @@
 	};
 
 	Twinkle.config.save = (e) => {
-		Morebits.status.init(document.querySelector('#twinkle-config-content'));
+		Morebits.status.init(document.getElementById('twinkle-config-content'));
 		const userjs = `${mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user]}:${mw.config.get(
 			'wgUserName'
 		)}/twinkleoptions.js`;

--- a/src/Twinkle/modules/twinklecopyvio.js
+++ b/src/Twinkle/modules/twinklecopyvio.js
@@ -17,8 +17,8 @@
 			mw.config.get('wgNamespaceNumber') < 0 ||
 			!mw.config.get('wgArticleId') ||
 			(mw.config.get('wgNamespaceNumber') === 6 &&
-				(document.querySelector('#mw-sharedupload') ||
-					(!document.querySelector('#mw-imagepage-section-filehistory') && !Morebits.isPageRedirect())))
+				(document.getElementById('mw-sharedupload') ||
+					(!document.getElementById('mw-imagepage-section-filehistory') && !Morebits.isPageRedirect())))
 		) {
 			return;
 		}

--- a/src/Twinkle/modules/twinklediff.js
+++ b/src/Twinkle/modules/twinklediff.js
@@ -53,7 +53,7 @@
 		if (me) {
 			user = mw.config.get('wgUserName');
 		} else {
-			const node = document.querySelector('#mw-diff-ntitle2');
+			const node = document.getElementById('mw-diff-ntitle2');
 			if (!node) {
 				// nothing to do?
 				return;
@@ -69,7 +69,7 @@
 			rvstartid: mw.config.get('wgCurRevisionId') - 1,
 			rvuser: user,
 		};
-		Morebits.status.init(document.querySelector('#mw-content-text'));
+		Morebits.status.init(document.getElementById('mw-content-text'));
 		const qiuwen_api = new Morebits.wiki.api(
 			wgULS('抓取最初贡献者信息', '抓取最初貢獻者資訊'),
 			query,

--- a/src/Twinkle/modules/twinklefluff.js
+++ b/src/Twinkle/modules/twinklefluff.js
@@ -255,7 +255,7 @@
 			// Don't load if there's a single revision or weird diff (cur on latest)
 			if (mw.config.get('wgDiffOldId') && mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId')) {
 				// Add a [restore this revision] link to the older revision
-				const oldTitle = document.querySelector('#mw-diff-otitle1').parentNode;
+				const oldTitle = document.getElementById('mw-diff-otitle1').parentNode;
 				const revertToRevision = Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgDiffOldId');
 				oldTitle.insertBefore(revertToRevision, oldTitle.firstChild);
 				if (Twinkle.getPref('customRevertSummary').length > 0) {
@@ -283,9 +283,9 @@
 			warnFromTalk('ntitle'); // Add quick-warn link to user talk link
 			// Add either restore or rollback links to the newer revision
 			// Don't show if there's a single revision or weird diff (prev on first)
-			if (document.querySelector('#differences-nextlink')) {
+			if (document.getElementById('differences-nextlink')) {
 				// Not latest revision, add [restore this revision] link to newer revision
-				const newTitle = document.querySelector('#mw-diff-ntitle1').parentNode;
+				const newTitle = document.getElementById('mw-diff-ntitle1').parentNode;
 				newTitle.insertBefore(
 					Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgDiffNewId'),
 					newTitle.firstChild
@@ -294,7 +294,7 @@
 				Twinkle.getPref('showRollbackLinks').includes('diff') &&
 				mw.config.get('wgDiffOldId') &&
 				(mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') ||
-					document.querySelector('#differences-prevlink'))
+					document.getElementById('differences-prevlink'))
 			) {
 				// Normally .mw-userlink is a link, but if the
 				// username is hidden, it will be a span with
@@ -310,13 +310,13 @@
 				// checking a.mw-userlink instead, but revert() will
 				// need reworking around userHidden
 				const vandal = $('#mw-diff-ntitle2').find('.mw-userlink')[0].text;
-				const ntitle = document.querySelector('#mw-diff-ntitle1').parentNode;
+				const ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
 				ntitle.insertBefore(Twinkle.fluff.linkBuilder.rollbackLinks(vandal), ntitle.firstChild);
 			}
 		},
 		oldid: () => {
 			// Add a [restore this revision] link on old revisions
-			const title = document.querySelector('#mw-revision-info').parentNode;
+			const title = document.getElementById('mw-revision-info').parentNode;
 			title.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgRevisionId'), title.firstChild);
 		},
 	};
@@ -349,7 +349,7 @@
 
 			Morebits.status.init(notifyStatus);
 		} else {
-			Morebits.status.init(document.querySelector('#mw-content-text'));
+			Morebits.status.init(document.getElementById('mw-content-text'));
 			$('#catlinks').remove();
 		}
 		const params = {
@@ -384,7 +384,7 @@
 		if (document.getElementsByName('revertsummary')[0] !== undefined) {
 			summary = document.getElementsByName('revertsummary')[0].value;
 		}
-		Morebits.status.init(document.querySelector('#mw-content-text'));
+		Morebits.status.init(document.getElementById('mw-content-text'));
 		const query = {
 			action: 'query',
 			prop: ['info', 'revisions'],

--- a/src/Twinkle/modules/twinkleimage.js
+++ b/src/Twinkle/modules/twinkleimage.js
@@ -8,8 +8,8 @@
 	Twinkle.image = () => {
 		if (
 			mw.config.get('wgNamespaceNumber') === 6 &&
-			!document.querySelector('#mw-sharedupload') &&
-			document.querySelector('#mw-imagepage-section-filehistory')
+			!document.getElementById('mw-sharedupload') &&
+			document.getElementById('mw-imagepage-section-filehistory')
 		) {
 			Twinkle.addPortletLink(
 				Twinkle.image.callback,

--- a/src/Twinkle/modules/twinklespeedy.js
+++ b/src/Twinkle/modules/twinklespeedy.js
@@ -1075,7 +1075,7 @@
 				if (
 					params.deleteTalkPage &&
 					params.normalized !== 'o1' &&
-					!document.querySelector('#ca-talk').classList.contains('new')
+					!document.getElementById('ca-talk').classList.contains('new')
 				) {
 					const talkpage = new Morebits.wiki.page(
 						`${

--- a/src/Twinkle/modules/twinklestub.js
+++ b/src/Twinkle/modules/twinklestub.js
@@ -39,7 +39,7 @@
 		Window.addFooterLink(wgULS('小作品设置', '小作品設定'), 'H:TW/PREF#stub');
 		Window.addFooterLink(wgULS('Twinkle帮助', 'Twinkle說明'), 'H:TW/DOC#stub');
 		const form = new Morebits.quickForm(Twinkle.stub.callback.evaluate);
-		if (document.querySelectorAll('.patrollink').length) {
+		if (document.getElementsByClassName('patrollink').length) {
 			form.append({
 				type: 'checkbox',
 				list: [

--- a/src/Twinkle/modules/twinklexfd.js
+++ b/src/Twinkle/modules/twinklexfd.js
@@ -17,8 +17,8 @@
 			mw.config.get('wgNamespaceNumber') < 0 ||
 			!mw.config.get('wgArticleId') ||
 			(mw.config.get('wgNamespaceNumber') === 6 &&
-				(document.querySelector('#mw-sharedupload') ||
-					(!document.querySelector('#mw-imagepage-section-filehistory') && !Morebits.isPageRedirect())))
+				(document.getElementById('mw-sharedupload') ||
+					(!document.getElementById('mw-imagepage-section-filehistory') && !Morebits.isPageRedirect())))
 		) {
 			return;
 		}
@@ -102,7 +102,7 @@
 		const {form} = e.target;
 		const [old_area] = Morebits.quickForm.getElements(e.target.form, 'work_area');
 		let work_area = null;
-		const oldreasontextbox = form.querySelector('textarea');
+		const [oldreasontextbox] = form.getElementsByTagName('textarea');
 		let oldreason = oldreasontextbox ? oldreasontextbox.value : '';
 		const appendReasonBox = (xfd_cat) => {
 			switch (xfd_cat) {

--- a/src/UserRightsManager/modules/core.js
+++ b/src/UserRightsManager/modules/core.js
@@ -31,7 +31,7 @@ const assignPermission = (summary, revId, expiry) => {
 };
 
 const markAsDone = (closingRemarks) => {
-	const sectionNode = document.querySelector(`#User:${userName.replace(/"/g, '.22').replace(/ /g, '_')}`);
+	const sectionNode = document.getElementById(`User:${userName.replace(/"/g, '.22').replace(/ /g, '_')}`);
 	const [, sectionNumber] = $(sectionNode)
 		.siblings('.mw-editsection')
 		.find('a:not(.mw-editsection-visualeditor)')

--- a/src/morebits/morebits.js
+++ b/src/morebits/morebits.js
@@ -119,7 +119,7 @@
 	Morebits.isPageRedirect = () => {
 		return !!(
 			mw.config.get('wgIsRedirect') ||
-			document.querySelector('#softredirect') ||
+			document.getElementById('softredirect') ||
 			$('.box-RfD').length ||
 			$('.box-Redirect_category_shell').length
 		);
@@ -1020,13 +1020,13 @@
 			return element;
 			// for fieldsets, the label is the child <legend> element
 		} else if (element instanceof HTMLFieldSetElement) {
-			return element.querySelector('legend');
+			return element.getElementsByTagName('legend')[0];
 			// for textareas, the label is the sibling <h5> element
 		} else if (element instanceof HTMLTextAreaElement) {
-			return element.parentNode.querySelector('h5');
+			return element.parentNode.getElementsByTagName('h5')[0];
 		}
 		// for others, the label is the sibling <label> element
-		return element.parentNode.querySelector('label');
+		return element.parentNode.getElementsByTagName('label')[0];
 	};
 	/**
 	 * Gets the label text of the element.


### PR DESCRIPTION
Reverts qiuwenbaike/QiuwenGadgets#388

`getElementById`'s behaviors are different from `querySelector`'s. Directly replace `getElementById` with `querySelector` will cause fatal consequences.