### PR TITLE
build(Exprimental): migration to babel-plugin-polyfill-corejs3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,19 @@
 {
-	"presets": [
-		[
-			"@babel/preset-env",
-			{
-				"bugfixes": true,
-				"corejs": {
-					"version": "3.33",
-					"proposals": true
-				},
-				"modules": false,
-				"useBuiltIns": "usage"
-			}
-		]
-	],
+	"presets": ["@babel/preset-env"],
 	"plugins": [
 		"@babel/plugin-transform-member-expression-literals",
 		"@babel/plugin-transform-property-literals",
-		"@babel/plugin-transform-reserved-words"
+		"@babel/plugin-transform-reserved-words",
+		[
+			"polyfill-corejs3",
+			{
+				"bugfixes": true,
+				"version": "3.33",
+				"proposals": true,
+				"modules": false,
+				"method": "usage-global"
+			}
+		]
 	],
 	"compact": false
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"@types/prompts": "^2.4.9",
 		"@typescript-eslint/eslint-plugin": "^5.62.0",
 		"@typescript-eslint/parser": "^5.62.0",
+		"babel-plugin-polyfill-corejs3": "^0.8.6",
 		"browserslist-config-wikimedia": "latest",
 		"chalk": "^5.3.0",
 		"core-js": "^3.33.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^5.62.0
     version: 5.62.0(eslint@8.54.0)(typescript@5.3.2)
+  babel-plugin-polyfill-corejs3:
+    specifier: ^0.8.6
+    version: 0.8.6(@babel/core@7.23.3)
   browserslist-config-wikimedia:
     specifier: latest
     version: 0.5.1


### PR DESCRIPTION
see <https://babeljs.io/docs/roadmap#continue-developing-the-babel-polyfills-project>. only do minor changes to target codes.