### PR TITLE
fix(Twinkle): add console.warn message

### DIFF
--- a/src/Twinkle/modules/twinkle.js
+++ b/src/Twinkle/modules/twinkle.js
@@ -6,6 +6,7 @@
 	// Wrap with anonymous function
 	// Check if account is experienced enough to use Twinkle
 	if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirmed')) {
+		console.warn('[Twinkle]非确认用户或自动确认用户，Twinkle不会运行。');
 		return;
 	}
 	const Twinkle = {};


### PR DESCRIPTION
一般情况下小工具在非自确（确认）用户情况下根本不会显示，本处仅为方便特殊情况下的调试，不影响实际效果。