### PR TITLE
Potential fix for code scanning alert no. 150: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/qiuwenbaike/QiuwenGadgets/security/code-scanning/150](https://github.com/qiuwenbaike/QiuwenGadgets/security/code-scanning/150)

Add an explicit `permissions` block at the workflow root (preferred here since there is one job) to enforce least privilege for `GITHUB_TOKEN`. For this lint workflow, set:

- `contents: read`

This is sufficient for checkout and general read-only CI operations, and does not change functional behavior of linting.  
Edit **`.github/workflows/lint.yml`** by inserting the permissions block after the `on:` trigger section (before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
