### PR TITLE
Fix DiscussionTools positioning issue

### DIFF
--- a/src/SiteCommon_Talkpage/modules/discussionTools.less
+++ b/src/SiteCommon_Talkpage/modules/discussionTools.less
@@ -3,11 +3,6 @@
 	display: none;
 }
 
-/* 修复DiscussionTools以链接开头下划线位置错误 */
-span[data-mw-comment-start] {
-	top: 0 !important;
-}
-
 /* 修复DiscussionTools溢出的问题，让该界面成为浮窗 */
 .ext-discussiontools-ui-replyWidget {
 	body & {


### PR DESCRIPTION
目前在求闻百科的讨论页中，点击DiscussionTools生成的讨论链接（例如[此链接](https://www.qiuwenbaike.cn/wiki/Qiuwen_talk:茶馆/消息#c-MediaWiki_message_delivery-20260715152300-邀请您参加求闻百科2026年暑期编辑松)）时，页面会错误地定位到顶部，而非对应的评论位置。

经排查，该链接旨在锚定至一个空的 `span` 元素（如 `#c-MediaWiki_message_delivery-...`），但现有样式 `span[data-mw-comment-start] { top: 0 !important; }` 强制将其置顶，导致定位失效。在浏览器调试工具中禁用该样式后，定位功能即可恢复正常。因此，本 PR 删除了这段 CSS 代码。

需要注意的是，该样式此前被特意添加，注释说明为“修复 DiscussionTools 以链接开头下划线位置错误”。由于我不了解当初添加该样式的具体背景及潜在影响，不确定直接删除是否为最佳方案。恳请维护者协助评估此改动是否合理，或提供相关上下文信息。

Currently, on Qiuwen Baike talk pages, clicking a DiscussionTools-generated discussion link (e.g., [this link](https://www.qiuwenbaike.cn/wiki/Qiuwen_talk:茶馆/消息#c-MediaWiki_message_delivery-20260715152300-邀请您参加求闻百科2026年暑期编辑松)) incorrectly scrolls the page to the top instead of navigating to the corresponding comment.

Upon investigation, the link is intended to anchor to an empty `span` element (e.g., `#c-MediaWiki_message_delivery-...`). However, the existing CSS rule `span[data-mw-comment-start] { top: 0 !important; }` forces this element to the top of the page, breaking the scroll-to-anchor behavior. Disabling this style in the browser dev tools restores correct navigation. Accordingly, this PR removes the aforementioned CSS rule.

It should be noted that this style was previously added intentionally, with a comment stating it was to "fix incorrect underline positioning for links at the start of DiscussionTools comments." As I am unaware of the original context or potential side effects of that change, I am uncertain whether removing it outright is the best approach. I would appreciate it if maintainers could review this modification and advise on its appropriateness, or provide relevant background information.